### PR TITLE
Use picture tag for responsive homepage image

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ To customize the appearance, modify `static/css/style.css` or add your own CSS f
 ### Images
 
 For optimal performance, use WebP images when possible. The theme works well with responsive images.
+Consider using the [pelican-webp-images](https://github.com/tedsteinmann/pelican-webp-images) plugin to automatically generate multiple sizes. The homepage template (`index.html`) now renders the about page image using a `<picture>` tag so responsive WebP sources are served when available.
 
 ## Troubleshooting
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,20 +34,20 @@
 
         <!-- Image Content -->
         <div style="display: flex; align-items: flex-end;">
-            <img src="static/{{ about_page.image | replace('.webp', '-600.webp') }}" 
-                 srcset="
-                   static/{{ about_page.image | replace('.webp', '-300.webp') }} 300w,
-                   static/{{ about_page.image | replace('.webp', '-600.webp') }} 600w
-                 "
-                 sizes="(max-width: 768px) 300px, 600px"
-                 decoding="async" 
-                 alt="Illustration of {{ AUTHOR }}" 
-                 class="radius responsive-image portrait-image" 
-                 fetchpriority="high" 
-                 width="785" 
-                 height="1047"
-                 title="Portrait of {{ AUTHOR }}"
-                 style="display: block; max-width: 100%; height: auto;">
+            <picture>
+                <source srcset="static/{{ about_page.image | replace('.webp', '-300.webp') }}" media="(max-width: 400px)" type="image/webp">
+                <source srcset="static/{{ about_page.image | replace('.webp', '-600.webp') }}" media="(max-width: 800px)" type="image/webp">
+                <source srcset="static/{{ about_page.image | replace('.webp', '-1200.webp') }}" media="(max-width: 1200px)" type="image/webp">
+                <img src="static/{{ about_page.image }}"
+                     alt="Illustration of {{ AUTHOR }}"
+                     class="radius responsive-image portrait-image"
+                     decoding="async"
+                     fetchpriority="high"
+                     width="785"
+                     height="1047"
+                     title="Portrait of {{ AUTHOR }}"
+                     style="display: block; max-width: 100%; height: auto;">
+            </picture>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- render the About image with `<picture>` and `<source>` tags
- document pelican-webp-images plugin usage

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68860f7bafe483319ecaf60c5e2ccd02