### PR TITLE
Add homepage index markdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ SOCIAL = (
 3. Create content structure:
    ```
    content/
+   ├── index.md          # Provides homepage content (not in navigation)
    ├── about.md          # Will appear as "About" in navigation
    └── articles/
        └── first-post.md # category: blog → "Blog" in navigation
@@ -99,6 +100,7 @@ ARTICLE_EXCLUDES = ['drafts', 'templates', 'static']  # Exclude from articles
 
 ```
 content/
+├── index.md              # Homepage content (hidden from navigation)
 ├── about.md              # Page → "About" in navigation
 ├── contact.md            # Page → "Contact" in navigation
 ├── articles/             # Articles folder
@@ -165,7 +167,7 @@ To customize the appearance, modify `static/css/style.css` or add your own CSS f
 ### Images
 
 For optimal performance, use WebP images when possible. The theme works well with responsive images.
-Consider using the [pelican-webp-images](https://github.com/tedsteinmann/pelican-webp-images) plugin to automatically generate multiple sizes. The homepage template (`index.html`) now renders the about page image using a `<picture>` tag so responsive WebP sources are served when available.
+Consider using the [pelican-webp-images](https://github.com/tedsteinmann/pelican-webp-images) plugin to automatically generate multiple sizes. The homepage template (`index.html`) now renders the image defined in `index.md` using a `<picture>` tag so responsive WebP sources are served when available.
 
 ## Troubleshooting
 
@@ -199,6 +201,7 @@ This theme is optimized for portfolio sites. Structure your content as:
 
 ```
 content/
+├── index.md              # Homepage content (hidden from navigation)
 ├── about.md              # Page for "About" navigation
 ├── articles/             # Articles organized by category
 │   ├── blog-post-1.md    # category: blog

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,13 @@
 {{ SITENAME }}
 
 {% block content %}
-{% set about_page = pages | selectattr("title", "equalto", "About") | first %}
+{#
+  Pull homepage content from a page titled "Index". This file should live in
+  the content root and will not appear in navigation (the navigation template
+  ignores pages with this title). The page metadata can define `image` and a
+  summary or full content.
+#}
+{% set index_page = pages | selectattr("title", "equalto", "Index") | first %}
     <!-- Grid Layout -->
     <div class="grid">
         <!-- Text Content -->
@@ -11,7 +17,7 @@
             <h1><strong>{{ AUTHOR }}</strong></h1>
             <h2 class="secondary">Portfolio</h2>
             <p>
-                {{ about_page.summary }}
+                {{ index_page.summary or index_page.content }}
             </p>
 
             <!-- Social Media Buttons -->
@@ -35,10 +41,10 @@
         <!-- Image Content -->
         <div style="display: flex; align-items: flex-end;">
             <picture>
-                <source srcset="static/{{ about_page.image | replace('.webp', '-300.webp') }}" media="(max-width: 400px)" type="image/webp">
-                <source srcset="static/{{ about_page.image | replace('.webp', '-600.webp') }}" media="(max-width: 800px)" type="image/webp">
-                <source srcset="static/{{ about_page.image | replace('.webp', '-1200.webp') }}" media="(max-width: 1200px)" type="image/webp">
-                <img src="static/{{ about_page.image }}"
+                <source srcset="static/{{ index_page.image | replace('.webp', '-300.webp') }}" media="(max-width: 400px)" type="image/webp">
+                <source srcset="static/{{ index_page.image | replace('.webp', '-600.webp') }}" media="(max-width: 800px)" type="image/webp">
+                <source srcset="static/{{ index_page.image | replace('.webp', '-1200.webp') }}" media="(max-width: 1200px)" type="image/webp">
+                <img src="static/{{ index_page.image }}"
                      alt="Illustration of {{ AUTHOR }}"
                      class="radius responsive-image portrait-image"
                      decoding="async"

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -16,11 +16,13 @@
 <ul>
   <!-- Root-level pages (like About) -->
   {% for p in pages %}
+    {% if p.title != "Index" %}
     <li>
       <a href="/{{ p.url }}" class="contrast"{% if p == page %} aria-current="page"{% endif %}>
         {{ p.title }}
       </a>
     </li>
+    {% endif %}
   {% endfor %}
 
   <!-- Dynamically generated categories -->


### PR DESCRIPTION
## Summary
- support homepage data via `index.md`
- exclude `index.md` from nav
- document homepage setup in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68861cf2b1388331ada152209ebce416