### PR TITLE
Unify link styles across content

### DIFF
--- a/templates/article_item.html
+++ b/templates/article_item.html
@@ -1,13 +1,13 @@
 <li>
     <h3>
-        <a href="/{{ article.url }}" class="contrast">{{ article.title }}</a>
+        <a href="/{{ article.url }}">{{ article.title }}</a>
     </h3>
     <strong>Category:</strong> 
-    <a href="{{ SITEURL }}/{{ article.category.url }}" class="secondary">{{ article.category }}</a>
+    <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
     <br>
     <strong>Tags:</strong> 
     {% for tag in article.tags %}
-        <a href="/tag/{{ tag }}" class="secondary">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+        <a href="/tag/{{ tag }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
     {% endfor %}
     <br>
     <small>Published on {{ article.date.strftime("%B %d, %Y") }}</small>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -5,10 +5,10 @@
             <h2>Feed</h2>
             <ul>
                 {% if FEED_ALL_ATOM %}
-                        <li><a href="{{ FEED_DOMAIN }}/{% if FEED_ALL_ATOM_URL %}{{ FEED_ALL_ATOM_URL }}{% else %}{{ FEED_ALL_ATOM }}{% endif %}" class="contrast" type="application/atom+xml" rel="alternate">atom feed</a></li>
+                        <li><a href="{{ FEED_DOMAIN }}/{% if FEED_ALL_ATOM_URL %}{{ FEED_ALL_ATOM_URL }}{% else %}{{ FEED_ALL_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate">atom feed</a></li>
                 {% endif %}
                 {% if FEED_ALL_RSS %}
-                        <li><a href="{{ FEED_DOMAIN }}/{% if FEED_ALL_RSS_URL %}{{ FEED_ALL_RSS_URL }}{% else %}{{ FEED_ALL_RSS }}{% endif %}" class="contrast" type="application/rss+xml" rel="alternate">rss feed</a></li>
+                        <li><a href="{{ FEED_DOMAIN }}/{% if FEED_ALL_RSS_URL %}{{ FEED_ALL_RSS_URL }}{% else %}{{ FEED_ALL_RSS }}{% endif %}" type="application/rss+xml" rel="alternate">rss feed</a></li>
                 {% endif %}
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- remove Pico-specific classes from article links
- drop contrast styling from RSS/Atom feed links

## Testing
- `python -m compileall -q templates static`

------
https://chatgpt.com/codex/tasks/task_e_6886cf035c288331b31ad5bf752f8161