### PR TITLE
Load site.yml data into Pelican config and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,51 @@ git clone https://github.com/tedsteinmann/pelican-pico-theme.git themes/pico
 
 ## Configuration
 
+Site metadata can be defined in a `site.yml` file placed next to your Pelican configuration:
+
+```yaml
+site:
+  title: Your Site Name
+  author: Your Name
+  url: https://example.com
+  description: Your site description for SEO and social sharing
+  image: static/portrait.webp
+
+homepage:
+  title: Your Name
+  subtitle: Developer
+  summary: Building things
+  image: static/portrait.webp
+
+seo:
+  og_image: static/social-card.jpg
+  twitter_username: yourhandle
+
+social:
+  - name: LinkedIn
+    url: https://www.linkedin.com/in/yourusername/
+  - name: GitHub
+    url: https://github.com/yourusername
+```
+
+These values populate Pelican configuration variables used throughout the templates:
+
+- `SITENAME` – site name shown in navigation and metadata
+- `AUTHOR` – author meta tag and homepage fallback
+- `SITEURL` – canonical site URL for links and social cards
+- `DESCRIPTION` – default description for meta and social tags
+- `SITE_IMAGE` – fallback portrait image for the homepage
+- `HOMEPAGE` – mapping with `title`, `subtitle`, `summary`, `image`
+- `SEO` – mapping with `og_image` and `twitter_username`
+- `SOCIAL` – list of social links (`name`, `url`, optional `button_class`)
+- `DEFAULT_LANG` – language code used in the `<html>` tag (defaults to `en`)
+
+If you do not use `site.yml`, define these variables manually in `pelicanconf.py` or `publishconf.py`.
+
 Add the following to your `pelicanconf.py`:
 
 ```python
 THEME = 'themes/pico'
-
-# Basic site settings
-AUTHOR = 'Your Name'
-SITENAME = 'Your Site Name'
-DESCRIPTION = 'Your site description for SEO and social sharing'
 
 # Content paths
 PATH = 'content'                      # Your content directory
@@ -48,19 +84,12 @@ ARTICLE_PATHS = ['articles']          # Articles in subdirectory
 # Navigation settings
 DISPLAY_PAGES_ON_MENU = True          # Show pages in navigation
 DISPLAY_CATEGORIES_ON_MENU = True     # Show categories in navigation
-
-# Social Media Links (optional)
-SOCIAL = (
-    ("LinkedIn", "https://www.linkedin.com/in/yourusername/"),
-    ("Twitter", "https://www.twitter.com/yourusername"),
-    ("GitHub", "https://github.com/yourusername"),
-)
 ```
 
 ## Quick Start
 
 1. Install the theme
-2. Update your `pelicanconf.py` with the configuration above
+2. Create `site.yml` and update your `pelicanconf.py` with the configuration above
 3. Create content structure:
    ```
    content/

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import yaml
+
+BASE_DIR = Path(__file__).parent
+site_file = BASE_DIR / 'site.yml'
+data = {}
+if site_file.exists():
+    with open(site_file, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f) or {}
+
+site = data.get('site', {})
+SITENAME = site.get('title', '')
+AUTHOR = site.get('author', '')
+SITEURL = site.get('url', '')
+DESCRIPTION = site.get('description', '')
+SITE_IMAGE = site.get('image', '')
+
+HOMEPAGE = data.get('homepage', {})
+SEO = data.get('seo', {})
+SOCIAL = data.get('social', [])

--- a/publishconf.py
+++ b/publishconf.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import yaml
+
+BASE_DIR = Path(__file__).parent
+site_file = BASE_DIR / 'site.yml'
+data = {}
+if site_file.exists():
+    with open(site_file, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f) or {}
+
+site = data.get('site', {})
+SITENAME = site.get('title', '')
+AUTHOR = site.get('author', '')
+SITEURL = site.get('url', '')
+DESCRIPTION = site.get('description', '')
+SITE_IMAGE = site.get('image', '')
+
+HOMEPAGE = data.get('homepage', {})
+SEO = data.get('seo', {})
+SOCIAL = data.get('social', [])
+
+RELATIVE_URLS = False

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,37 +8,33 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="{{ AUTHOR }}" />
     <meta name="description" content="{{ DESCRIPTION }}" />
-
-    {% if SITESUBTITLE %}
-      <meta name="description" content="{{ SITESUBTITLE }}" />
-    {% endif %}
     
     <!-- Open Graph / Social Media Meta Tags -->
     <meta property="og:type" content="{% if article %}article{% else %}website{% endif %}" />
-    <meta property="og:title" content="{% if article %}{{ article.title }}{% elif page %}{{ page.title }}{% else %}{{ SITE_DATA.site.title or SITENAME }}{% endif %}" />
-    <meta property="og:description" content="{% if article and article.summary %}{{ article.summary }}{% elif page and page.summary %}{{ page.summary }}{% else %}{{ SITE_DATA.site.description or DESCRIPTION }}{% endif %}" />
-    <meta property="og:url" content="{{ SITE_DATA.site.url or SITEURL }}{% if article %}{{ article.url }}{% elif page %}{{ page.url }}{% endif %}" />
+    <meta property="og:title" content="{% if article %}{{ article.title }}{% elif page %}{{ page.title }}{% else %}{{ SITENAME }}{% endif %}" />
+    <meta property="og:description" content="{% if article and article.summary %}{{ article.summary }}{% elif page and page.summary %}{{ page.summary }}{% else %}{{ DESCRIPTION }}{% endif %}" />
+    <meta property="og:url" content="{{ SITEURL }}{% if article %}{{ article.url }}{% elif page %}{{ page.url }}{% endif %}" />
     {% if article and article.og_image %}
-    <meta property="og:image" content="{{ SITE_DATA.site.url or SITEURL }}/static/{{ article.og_image }}" />
-    {% elif SITE_DATA.seo.og_image %}
-    <meta property="og:image" content="{{ SITE_DATA.site.url or SITEURL }}/static/{{ SITE_DATA.seo.og_image }}" />
+    <meta property="og:image" content="{{ SITEURL }}/static/{{ article.og_image }}" />
+    {% elif SEO.og_image %}
+    <meta property="og:image" content="{{ SITEURL }}/static/{{ SEO.og_image }}" />
     {% endif %}
-    {% if article and article.og_image or SITE_DATA.seo.og_image %}
+    {% if article and article.og_image or SEO.og_image %}
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     {% endif %}
-    
+
     <!-- Twitter Card Meta Tags -->
-    {% if SITE_DATA.seo.twitter_username %}
+    {% if SEO.twitter_username %}
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:creator" content="@{{ SITE_DATA.seo.twitter_username }}" />
-    <meta name="twitter:title" content="{% if article %}{{ article.title }}{% elif page %}{{ page.title }}{% else %}{{ SITE_DATA.site.title or SITENAME }}{% endif %}" />
-    <meta name="twitter:description" content="{% if article and article.summary %}{{ article.summary }}{% elif page and page.summary %}{{ page.summary }}{% else %}{{ SITE_DATA.site.description or DESCRIPTION }}{% endif %}" />
+    <meta name="twitter:creator" content="@{{ SEO.twitter_username }}" />
+    <meta name="twitter:title" content="{% if article %}{{ article.title }}{% elif page %}{{ page.title }}{% else %}{{ SITENAME }}{% endif %}" />
+    <meta name="twitter:description" content="{% if article and article.summary %}{{ article.summary }}{% elif page and page.summary %}{{ page.summary }}{% else %}{{ DESCRIPTION }}{% endif %}" />
     {% if article and article.og_image %}
-      <meta name="twitter:image" content="{{ SITE_DATA.site.url or SITEURL }}/static/{{ article.og_image }}" />
-    {% elif SITE_DATA.seo.og_image %}
-      <meta name="twitter:image" content="{{ SITE_DATA.site.url or SITEURL }}/static/{{ SITE_DATA.seo.og_image }}" />
+      <meta name="twitter:image" content="{{ SITEURL }}/static/{{ article.og_image }}" />
+    {% elif SEO.og_image %}
+      <meta name="twitter:image" content="{{ SITEURL }}/static/{{ SEO.og_image }}" />
     {% endif %}
     {% endif %}
     
@@ -54,7 +50,6 @@
     <main>
         <section id="index">
             <div class="container">
-                <h2>{{ title }}</h2>
                 {% block content %}{% endblock %}
             </div>
         </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,18 +1,13 @@
 {% extends "base.html" %}
 
-{{ SITENAME }}
-
 {% block content %}
-{#
-  Homepage content is now pulled from site.yml data file via SITE_DATA
-#}
-{% set homepage = SITE_DATA.get('homepage', {}) %}
-{% set social = SITE_DATA.get('social', []) %}
+{% set homepage = HOMEPAGE %}
+{% set social = SOCIAL %}
     <!-- Grid Layout -->
     <div class="grid">
         <!-- Text Content -->
         <div>
-            <h1><strong>{{ homepage.title or SITE_DATA.site.title or AUTHOR }}</strong></h1>
+            <h1><strong>{{ homepage.title or SITENAME or AUTHOR }}</strong></h1>
             {% if homepage.subtitle %}<h2 class="secondary">{{ homepage.subtitle }}</h2>{% endif %}
             {% if homepage.summary %}<p>{{ homepage.summary }}</p>{% endif %}
 
@@ -29,18 +24,18 @@
 
         <!-- Image Content -->
         <div style="display: flex; align-items: flex-end;">
-            {% set portrait_image = homepage.image or SITE_DATA.site.image %}
+            {% set portrait_image = homepage.image or SITE_IMAGE %}
             {% if portrait_image %}
             <picture>
                 <source srcset="static/{{ portrait_image | replace('.webp', '-300.webp') }}" media="(max-width: 400px)" type="image/webp">
                 <source srcset="static/{{ portrait_image | replace('.webp', '-600.webp') }}" media="(max-width: 800px)" type="image/webp">
                 <source srcset="static/{{ portrait_image | replace('.webp', '-1200.webp') }}" media="(max-width: 1200px)" type="image/webp">
                 <img src="static/{{ portrait_image }}"
-                     alt="Portrait of {{ homepage.title or SITE_DATA.site.title or AUTHOR }}"
+                     alt="Portrait of {{ homepage.title or SITENAME or AUTHOR }}"
                      class="radius responsive-image portrait-image"
                      decoding="async"
                      fetchpriority="high"
-                     title="Portrait of {{ homepage.title or SITE_DATA.site.title or AUTHOR }}"
+                     title="Portrait of {{ homepage.title or SITENAME or AUTHOR }}"
                      style="display: block; max-width: 100%; height: auto; aspect-ratio: auto;">
             </picture>
             {% endif %}


### PR DESCRIPTION
## Summary
- load site.yml settings into Pelican config variables (SITENAME, AUTHOR, SITEURL, DESCRIPTION, etc.)
- expose HOMEPAGE, SEO and SOCIAL config variables for templates
- document required config variables in README and clean up unused base template markup

## Testing
- `python -m py_compile pelicanconf.py publishconf.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0f2ac1d3c83318d74f5b47bc0dcef